### PR TITLE
[WIP] Add arbitrary language support

### DIFF
--- a/kernel-extractor.py
+++ b/kernel-extractor.py
@@ -1,0 +1,10 @@
+import json
+from jupyter_client.kernelspec import KernelSpecManager
+
+specs = KernelSpecManager().get_all_specs()
+result = {}
+for key, spec in specs.items():
+    result[key] = spec
+
+result = json.dumps(result)
+print(result)


### PR DESCRIPTION
# Description
This pull request adds the ability to run any code snippet if you have the appropriate kernel installed on your machine. See Screenshot at the bottom for a visual.

# Usage
In order to run a code snippet for a particular language, you need the following:
* You need the [proper kernel installed](https://github.com/jupyter/jupyter/wiki/Jupyter-kernels)
* You need to add the proper language identifier by adding the language in the code blocks prepended by 'jupyter-'

~~~
```jupyter-python
from random import randrange

print("Hello from Python!")
print(randrange(100))
```
~~~

The reason for this small change is so the plugin doesn't need to run on every code block that just so happens to align with an installed kernel. As I write this I realize this isn't a great reason for this change so feel free to veto this item - it can be changed quite easily.

# Issues

One issue I have with this is making the post processor reusable for different languages. The main issue revolves around this snippet on line 97 of ```main.ts```:
```typescript
async postprocessor(src: string, el: HTMLElement, ctx: MarkdownPostProcessorContext) {
  const extractLanguageFromClass = (str: string) => str.split('-').pop();
  const kernel = this.settings.kernels.get(extractLanguageFromClass(el.classList[0]));
  if(!kernel)
	  return;
```

As far as I know, the only way to differentiate between languages using the same post processor is to grab the class list out of the HTMLElement and extract the language from the first entry. So far this is consistent but this feels quite hacky. I would love to know if there is an alternate solution.

# To Do's
- [x] Integrate Setup Scripts (the pre-work is done but there is currently nothing in place to add or change them - doesn't seem right to add functionality that removes a key feature of the plugin)
- [ ] Verify plugin works on Linux and Mac
- [x] Configure plugin to pull new .py file from github (similar to ```obsidian-jupyter.py```) OR rework to use command line from ```main.ts``` instead of having another file

# Screenshot

![image](https://user-images.githubusercontent.com/22444161/143793162-f32cdfbb-1263-446e-84c9-9ba2e67ba40b.png)
